### PR TITLE
redirect post-2FA vers destination initiale, frais de livraison et ré…

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -104,6 +104,7 @@
   "checkoutCancelMessage": "Your payment was cancelled. You can retry anytime.",
   "checkoutCancelTitle": "Payment cancelled",
   "checkoutCreateIntentError": "Unable to initialize payment.",
+  "checkoutShippingFees": "Shipping fees",
   "checkoutCreatingIntent": "Preparing payment...",
   "checkoutPay": "checkoutPay",
   "checkoutPaymentError": "Payment failed.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -104,6 +104,7 @@
   "checkoutCancelMessage": "Votre paiement a été annulé. Vous pouvez réessayer quand vous voulez.",
   "checkoutCancelTitle": "Paiement annulé",
   "checkoutCreateIntentError": "Impossible d'initialiser le paiement.",
+  "checkoutShippingFees": "Frais de livraison",
   "checkoutCreatingIntent": "Préparation du paiement...",
   "checkoutPay": "Payer",
   "checkoutPaymentError": "Le paiement a échoué.",

--- a/frontend/src/pages/auth/Verify2FA.tsx
+++ b/frontend/src/pages/auth/Verify2FA.tsx
@@ -27,7 +27,7 @@ export const Verify2FA: React.FC = () => {
       if(user.role === 'admin' || user.role === 'commercial') {
         navigate('/dashboard');
       } else {
-        navigate('/');
+        navigate(from ?? '/', { replace: true });
       }
       return;
     }

--- a/frontend/src/pages/frontoffice/stripe/Checkout.tsx
+++ b/frontend/src/pages/frontoffice/stripe/Checkout.tsx
@@ -31,6 +31,7 @@ export const Checkout: React.FC = () => {
   const [promoInput, setPromoInput] = useState('');
   const [promoCode, setPromoCode] = useState<string | undefined>(undefined);
   const [discountCents, setDiscountCents] = useState(0);
+  const [discountPercent, setDiscountPercent] = useState(0);
   const [promoError, setPromoError] = useState<string | null>(null);
   const [promoLoading, setPromoLoading] = useState(false);
 
@@ -40,8 +41,10 @@ export const Checkout: React.FC = () => {
     setPromoLoading(true);
     try {
       const result = await CartService.getInstance().applyPromo(promoInput.trim());
+      const cents = Math.round(result.discountAmount * 100);
       setPromoCode(result.promoCode);
-      setDiscountCents(Math.round(result.discountAmount * 100));
+      setDiscountCents(cents);
+      setDiscountPercent(subtotalCents > 0 ? Math.round((cents / subtotalCents) * 100) : 0);
       resetIntent();
     } catch (err) {
       setPromoError(err instanceof Error ? err.message : t('promoError'));
@@ -55,6 +58,7 @@ export const Checkout: React.FC = () => {
   const handleRemovePromo = () => {
     setPromoCode(undefined);
     setDiscountCents(0);
+    setDiscountPercent(0);
     setPromoInput('');
     setPromoError(null);
     resetIntent();
@@ -331,14 +335,14 @@ export const Checkout: React.FC = () => {
                 </div>
                 {shippingFeeCents > 0 && (
                   <div className="flex justify-between">
-                    <span className="text-xs text-gray-500">{t('shipping')}</span>
+                    <span className="text-xs text-gray-500">{t('checkoutShippingFees')}</span>
                     <span className="text-xs text-gray-500">{formatEuro(shippingFeeCents)}</span>
                   </div>
                 )}
                 {discountCents > 0 && (
                   <div className="flex justify-between text-green-600">
-                    <span className="text-xs">{t('discount') || 'Réduction'} ({promoCode})</span>
-                    <span className="text-xs">-{formatEuro(discountCents)}</span>
+                    <span className="text-xs">{t('discount')} ({promoCode})</span>
+                    <span className="text-xs">-{discountPercent}%</span>
                   </div>
                 )}
                 {recurringCents > 0 && (


### PR DESCRIPTION
corrections mineures tunnel de paiement

- Verify2FA.tsx : navigate('/') → navigate(from ?? '/', { replace: true })
  Le redirect post-2FA ignorait la destination initiale (ex: /checkout)
- Checkout.tsx : label frais de livraison via clé i18n dédiée checkoutShippingFees
- Checkout.tsx : réduction affichée en pourcentage dans le récap
  (dérivé de discountAmount / subtotalCents — discount_value absent de la réponse API)

Les autres bugs identifiés (effectiveAmountCents, CartProvider,
redirect login non-2FA) étaient déjà corrigés sur dev.